### PR TITLE
URL Cleanup

### DIFF
--- a/docs/spring-session-docs.gradle
+++ b/docs/spring-session-docs.gradle
@@ -45,11 +45,11 @@ asciidoctor {
 javadoc {
 	configure(options) {
 		links = [
-			"http://docs.spring.io/spring/docs/current/javadoc-api/",
-			"http://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
-			"http://docs.spring.io/spring-data-geode/docs/current/api/",
-			"http://docs.spring.io/spring-session/docs/${springSessionVersion}/api/",
-			"http://geode.apache.org/releases/latest/javadoc/index.html",
+			"https://docs.spring.io/spring/docs/current/javadoc-api/",
+			"https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
+			"https://docs.spring.io/spring-data-geode/docs/current/api/",
+			"https://docs.spring.io/spring-session/docs/${springSessionVersion}/api/",
+			"https://geode.apache.org/releases/latest/javadoc/index.html",
 		]
 	}
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://docs.spring.io/spring-data-geode/docs/current/api/ (301) migrated to:  
  https://docs.spring.io/spring-data-geode/docs/current/api/ ([https](https://docs.spring.io/spring-data-geode/docs/current/api/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html migrated to:  
  https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html ([https](https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html) result 200).
* http://docs.spring.io/spring-session/docs/ migrated to:  
  https://docs.spring.io/spring-session/docs/ ([https](https://docs.spring.io/spring-session/docs/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://geode.apache.org/releases/latest/javadoc/index.html migrated to:  
  https://geode.apache.org/releases/latest/javadoc/index.html ([https](https://geode.apache.org/releases/latest/javadoc/index.html) result 200).