### PR TITLE
URL Cleanup

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">

--- a/samples/boot/gemfire-with-gfsh-servers/src/main/resources/initializer-cache.xml
+++ b/samples/boot/gemfire-with-gfsh-servers/src/main/resources/initializer-cache.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- tag::cache-xml[] -->
-<cache xmlns="http://geode.apache.org/schema/cache"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+<cache xmlns="https://geode.apache.org/schema/cache"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="https://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
 	   version="1.0">
 
 	<initializer>

--- a/samples/xml/gemfire-clientserver/src/main/resources/META-INF/spring/session-server.xml
+++ b/samples/xml/gemfire-clientserver/src/main/resources/META-INF/spring/session-server.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
-	   xmlns:p="http://www.springframework.org/schema/p"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:context="https://www.springframework.org/schema/context"
+	   xmlns:gfe="https://www.springframework.org/schema/gemfire"
+	   xmlns:p="https://www.springframework.org/schema/p"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        https://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- tag::beans[] -->

--- a/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/spring/session-client.xml
+++ b/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/spring/session-client.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
-	   xmlns:p="http://www.springframework.org/schema/p"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:context="https://www.springframework.org/schema/context"
+	   xmlns:gfe="https://www.springframework.org/schema/gemfire"
+	   xmlns:p="https://www.springframework.org/schema/p"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        https://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- tag::beans[] -->

--- a/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app version="3.0" xmlns="https://java.sun.com/xml/ns/javaee"
+		xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="https://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 	<!--
 	- Location of the XML file that defines the root application context
 	- Applied by ContextLoaderListener.

--- a/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/spring/session.xml
+++ b/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/spring/session.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
-	   xmlns:p="http://www.springframework.org/schema/p"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:context="https://www.springframework.org/schema/context"
+	   xmlns:gfe="https://www.springframework.org/schema/gemfire"
+	   xmlns:p="https://www.springframework.org/schema/p"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        https://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- tag::beans[] -->

--- a/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app version="3.0" xmlns="https://java.sun.com/xml/ns/javaee"
+		xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="https://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 	<!--
 	- Location of the XML file that defines the root application context
 	- Applied by ContextLoaderListener.

--- a/spring-session-data-geode/src/test/resources/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests-context.xml
+++ b/spring-session-data-geode/src/test/resources/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests-context.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
-	   xmlns:p="http://www.springframework.org/schema/p"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:gfe="https://www.springframework.org/schema/gemfire"
+	   xmlns:p="https://www.springframework.org/schema/p"
+	   xmlns:util="https://www.springframework.org/schema/util"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+        https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).
* [ ] http://www.springframework.org/schema/p (404) with 4 occurrences migrated to:  
  https://www.springframework.org/schema/p ([https](https://www.springframework.org/schema/p) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://geode.apache.org/schema/cache/cache-1.0.xsd with 1 occurrences migrated to:  
  https://geode.apache.org/schema/cache/cache-1.0.xsd ([https](https://geode.apache.org/schema/cache/cache-1.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/gemfire/spring-gemfire.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/gemfire/spring-gemfire.xsd ([https](https://www.springframework.org/schema/gemfire/spring-gemfire.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 7 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://geode.apache.org/schema/cache with 2 occurrences migrated to:  
  https://geode.apache.org/schema/cache ([https](https://geode.apache.org/schema/cache) result 301).
* [ ] http://www.springframework.org/schema/beans with 8 occurrences migrated to:  
  https://www.springframework.org/schema/beans ([https](https://www.springframework.org/schema/beans) result 301).
* [ ] http://www.springframework.org/schema/context with 6 occurrences migrated to:  
  https://www.springframework.org/schema/context ([https](https://www.springframework.org/schema/context) result 301).
* [ ] http://www.springframework.org/schema/gemfire with 8 occurrences migrated to:  
  https://www.springframework.org/schema/gemfire ([https](https://www.springframework.org/schema/gemfire) result 301).
* [ ] http://www.springframework.org/schema/util with 8 occurrences migrated to:  
  https://www.springframework.org/schema/util ([https](https://www.springframework.org/schema/util) result 301).
* [ ] http://java.sun.com/xml/ns/javaee with 4 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee ([https](https://java.sun.com/xml/ns/javaee) result 302).
* [ ] http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd) result 302).