### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,4 +77,4 @@ at http://projects.spring.io/spring-session/
 
 = License
 
-_Spring Session_ is Open Source Software released under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
+_Spring Session_ is Open Source Software released under the https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">

--- a/docs/spring-session-docs.gradle
+++ b/docs/spring-session-docs.gradle
@@ -45,11 +45,11 @@ asciidoctor {
 javadoc {
 	configure(options) {
 		links = [
-			"http://docs.spring.io/spring/docs/current/javadoc-api/",
-			"http://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
-			"http://docs.spring.io/spring-data-geode/docs/current/api/",
-			"http://docs.spring.io/spring-session/docs/${springSessionVersion}/api/",
-			"http://geode.apache.org/releases/latest/javadoc/index.html",
+			"https://docs.spring.io/spring/docs/current/javadoc-api/",
+			"https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
+			"https://docs.spring.io/spring-data-geode/docs/current/api/",
+			"https://docs.spring.io/spring-session/docs/${springSessionVersion}/api/",
+			"https://geode.apache.org/releases/latest/javadoc/index.html",
 		]
 	}
 }

--- a/docs/spring-session-docs.gradle
+++ b/docs/spring-session-docs.gradle
@@ -46,8 +46,8 @@ javadoc {
 	configure(options) {
 		links = [
 			"https://docs.spring.io/spring/docs/current/javadoc-api/",
-			"https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
-			"https://docs.spring.io/spring-data-geode/docs/current/api/",
+			"https://docs.spring.io/spring-data/commons/docs/current/api/index.html",
+			"https://docs.spring.io/spring-data/geode/docs/current/api/",
 			"https://docs.spring.io/spring-session/docs/${springSessionVersion}/api/",
 			"https://geode.apache.org/releases/latest/javadoc/index.html",
 		]

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1670,7 +1670,7 @@ We appreciate https://help.github.com/articles/using-pull-requests/[Pull Request
 === License
 
 Spring Session for {data-store-name} and Spring Session for Pivotal GemFire are Open Source Software
-released under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
+released under the https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
 
 [[minimum-requirements]]
 == Minimum Requirements

--- a/docs/src/integration-test/java/docs/gemfire/indexing/HttpSessionGemFireCustomIndexingIntegrationTests.java
+++ b/docs/src/integration-test/java/docs/gemfire/indexing/HttpSessionGemFireCustomIndexingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/src/integration-test/java/docs/gemfire/indexing/HttpSessionGemFireIndexingIntegrationTests.java
+++ b/docs/src/integration-test/java/docs/gemfire/indexing/HttpSessionGemFireIndexingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire-with-gfsh-servers/src/main/java/sample/client/Application.java
+++ b/samples/boot/gemfire-with-gfsh-servers/src/main/java/sample/client/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire-with-gfsh-servers/src/main/resources/initializer-cache.xml
+++ b/samples/boot/gemfire-with-gfsh-servers/src/main/resources/initializer-cache.xml
@@ -2,7 +2,7 @@
 <!-- tag::cache-xml[] -->
 <cache xmlns="http://geode.apache.org/schema/cache"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+	   xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
 	   version="1.0">
 
 	<initializer>

--- a/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/client/Application.java
+++ b/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/client/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/client/model/RequestScopedProxyBean.java
+++ b/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/client/model/RequestScopedProxyBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/client/model/SessionScopedProxyBean.java
+++ b/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/client/model/SessionScopedProxyBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/server/GemFireServer.java
+++ b/samples/boot/gemfire-with-scoped-proxies/src/main/java/sample/server/GemFireServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire/src/integration-test/java/sample/AttributeTests.java
+++ b/samples/boot/gemfire/src/integration-test/java/sample/AttributeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire/src/integration-test/java/sample/pages/HomePage.java
+++ b/samples/boot/gemfire/src/integration-test/java/sample/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire/src/main/java/sample/client/Application.java
+++ b/samples/boot/gemfire/src/main/java/sample/client/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire/src/main/java/sample/server/GemFireServer.java
+++ b/samples/boot/gemfire/src/main/java/sample/server/GemFireServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/gemfire/src/main/java/sample/server/NativeGemFireServer.java
+++ b/samples/boot/gemfire/src/main/java/sample/server/NativeGemFireServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-clientserver/src/integration-test/java/sample/AttributeTests.java
+++ b/samples/javaconfig/gemfire-clientserver/src/integration-test/java/sample/AttributeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-clientserver/src/integration-test/java/sample/pages/HomePage.java
+++ b/samples/javaconfig/gemfire-clientserver/src/integration-test/java/sample/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-clientserver/src/main/java/sample/client/ClientConfig.java
+++ b/samples/javaconfig/gemfire-clientserver/src/main/java/sample/client/ClientConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-clientserver/src/main/java/sample/client/Initializer.java
+++ b/samples/javaconfig/gemfire-clientserver/src/main/java/sample/client/Initializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-clientserver/src/main/java/sample/client/SessionServlet.java
+++ b/samples/javaconfig/gemfire-clientserver/src/main/java/sample/client/SessionServlet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-clientserver/src/main/java/sample/server/GemFireServer.java
+++ b/samples/javaconfig/gemfire-clientserver/src/main/java/sample/server/GemFireServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-p2p/src/integration-test/java/sample/AttributeTests.java
+++ b/samples/javaconfig/gemfire-p2p/src/integration-test/java/sample/AttributeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-p2p/src/integration-test/java/sample/pages/HomePage.java
+++ b/samples/javaconfig/gemfire-p2p/src/integration-test/java/sample/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-p2p/src/main/java/sample/Config.java
+++ b/samples/javaconfig/gemfire-p2p/src/main/java/sample/Config.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-p2p/src/main/java/sample/Initializer.java
+++ b/samples/javaconfig/gemfire-p2p/src/main/java/sample/Initializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/javaconfig/gemfire-p2p/src/main/java/sample/SessionServlet.java
+++ b/samples/javaconfig/gemfire-p2p/src/main/java/sample/SessionServlet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-clientserver/src/integration-test/java/sample/AttributeTests.java
+++ b/samples/xml/gemfire-clientserver/src/integration-test/java/sample/AttributeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-clientserver/src/integration-test/java/sample/pages/HomePage.java
+++ b/samples/xml/gemfire-clientserver/src/integration-test/java/sample/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-clientserver/src/main/java/sample/client/ClientServerReadyBeanPostProcessor.java
+++ b/samples/xml/gemfire-clientserver/src/main/java/sample/client/ClientServerReadyBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-clientserver/src/main/java/sample/client/SessionServlet.java
+++ b/samples/xml/gemfire-clientserver/src/main/java/sample/client/SessionServlet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-clientserver/src/main/java/sample/server/GemFireServer.java
+++ b/samples/xml/gemfire-clientserver/src/main/java/sample/server/GemFireServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-clientserver/src/main/resources/META-INF/spring/session-server.xml
+++ b/samples/xml/gemfire-clientserver/src/main/resources/META-INF/spring/session-server.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- tag::beans[] -->

--- a/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/spring/session-client.xml
+++ b/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/spring/session-client.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- tag::beans[] -->

--- a/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+		xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 	<!--
 	- Location of the XML file that defines the root application context
 	- Applied by ContextLoaderListener.

--- a/samples/xml/gemfire-p2p/src/integration-test/java/sample/AttributeTests.java
+++ b/samples/xml/gemfire-p2p/src/integration-test/java/sample/AttributeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-p2p/src/integration-test/java/sample/pages/HomePage.java
+++ b/samples/xml/gemfire-p2p/src/integration-test/java/sample/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-p2p/src/main/java/sample/SessionServlet.java
+++ b/samples/xml/gemfire-p2p/src/main/java/sample/SessionServlet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/spring/session.xml
+++ b/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/spring/session.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- tag::beans[] -->

--- a/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+		xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 	<!--
 	- Location of the XML file that defines the root application context
 	- Applied by ContextLoaderListener.

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/AbstractConcurrentSessionOperationsIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/AbstractConcurrentSessionOperationsIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/AbstractGemFireIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/AbstractGemFireIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerGemFireOperationsSessionRepositoryIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerGemFireOperationsSessionRepositoryIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerHttpSessionAttributesDeltaIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerHttpSessionAttributesDeltaIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerProxyRegionSessionOperationsIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerProxyRegionSessionOperationsIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ConcurrentSessionOperationsUsingClientCachingProxyRegionIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ConcurrentSessionOperationsUsingClientCachingProxyRegionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ConcurrentSessionOperationsUsingClientLocalRegionIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ConcurrentSessionOperationsUsingClientLocalRegionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ConcurrentSessionOperationsUsingClientProxyRegionIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/ConcurrentSessionOperationsUsingClientProxyRegionIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiPoolClientServerGemFireOperationsSessionRepositoryIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiPoolClientServerGemFireOperationsSessionRepositoryIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiThreadedClientServerHttpSessionAttributesDeltaIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiThreadedClientServerHttpSessionAttributesDeltaIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiThreadedHighlyConcurrentClientServerHttpSessionAccessIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiThreadedHighlyConcurrentClientServerHttpSessionAccessIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiThreadedLocalClientHttpSessionAttributesDeltaIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/MultiThreadedLocalClientHttpSessionAttributesDeltaIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/PeerCacheGemFireOperationsSessionRepositoryIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/PeerCacheGemFireOperationsSessionRepositoryIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/ConfigurerBasedGemFireHttpSessionConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/ConfigurerBasedGemFireHttpSessionConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/EnableGemFireHttpSessionEventsIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/EnableGemFireHttpSessionEventsIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/ExposingSpringSessionGemFireConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/ExposingSpringSessionGemFireConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionJavaConfigurationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionJavaConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/PropertyBasedGemFireHttpSessionConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/PropertyBasedGemFireHttpSessionConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/CustomSessionExpirationConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/CustomSessionExpirationConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/FixedTimeoutSessionExpirationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/FixedTimeoutSessionExpirationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/IdleOverFixedTimeoutSessionExpirationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/IdleOverFixedTimeoutSessionExpirationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/LazyTimeoutSessionExpirationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/expiration/LazyTimeoutSessionExpirationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/CompositePdxSerializerConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/CompositePdxSerializerConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/DataSerializationConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/DataSerializationConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/PdxSerializationConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/PdxSerializationConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/SessionSerializerConfiguredAsDataSerializerIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/SessionSerializerConfiguredAsDataSerializerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/SessionSerializerConfiguredAsPdxSerializerIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/SessionSerializerConfiguredAsPdxSerializerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/SessionSerializationWithDataSerializationDeltasAndJavaSerializationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/SessionSerializationWithDataSerializationDeltasAndJavaSerializationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/SessionSerializationWithDataSerializationDeltasAndPdxIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/SessionSerializationWithDataSerializationDeltasAndPdxIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializableSessionSerializerInitializerIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializableSessionSerializerInitializerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializerSessionSerializerAdapterIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializerSessionSerializerAdapterIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/pdx/SessionSerializationWithPdxRequiresNoServerConfigurationIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/serialization/pdx/SessionSerializationWithPdxRequiresNoServerConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/server/GemFireServer.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/server/GemFireServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/support/CustomIsDirtyPredicateIntegrationTests.java
+++ b/spring-session-data-geode/src/integration-test/java/org/springframework/session/data/gemfire/support/CustomIsDirtyPredicateIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/AbstractGemFireOperationsSessionRepository.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/AbstractGemFireOperationsSessionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/GemFireOperationsSessionRepository.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/GemFireOperationsSessionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/AbstractGemFireHttpSessionConfiguration.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/AbstractGemFireHttpSessionConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/EnableGemFireHttpSession.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/EnableGemFireHttpSession.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionConfiguration.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionAttributesIndexFactoryBean.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionAttributesIndexFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionCacheTypeAwareRegionFactoryBean.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionCacheTypeAwareRegionFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SpringSessionGemFireConfigurer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SpringSessionGemFireConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/SessionExpirationPolicy.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/SessionExpirationPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/config/FixedDurationExpirationSessionRepositoryBeanPostProcessor.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/config/FixedDurationExpirationSessionRepositoryBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/config/SessionExpirationTimeoutAware.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/config/SessionExpirationTimeoutAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/config/SessionExpirationTimeoutAwareBeanPostProcessor.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/config/SessionExpirationTimeoutAwareBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/repository/FixedDurationExpirationSessionRepository.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/repository/FixedDurationExpirationSessionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/support/FixedTimeoutSessionExpirationPolicy.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/support/FixedTimeoutSessionExpirationPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/support/IdleTimeoutSessionExpirationPolicy.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/support/IdleTimeoutSessionExpirationPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/support/SessionExpirationPolicyCustomExpiryAdapter.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/expiration/support/SessionExpirationPolicyCustomExpiryAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/SerializationException.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/SerializationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/SessionSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/SessionSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/AbstractDataSerializableSessionSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/AbstractDataSerializableSessionSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionAttributesSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionAttributesSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializableSessionSerializerInitializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializableSessionSerializerInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializerSessionSerializerAdapter.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializerSessionSerializerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/support/WirableDataSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/data/support/WirableDataSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/AbstractPdxSerializableSessionSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/AbstractPdxSerializableSessionSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/provider/PdxSerializableSessionSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/provider/PdxSerializableSessionSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/support/ComposablePdxSerializer.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/support/ComposablePdxSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/support/PdxSerializerSessionSerializerAdapter.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/serialization/pdx/support/PdxSerializerSessionSerializerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/AbstractSession.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/AbstractSession.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/DeltaAwareDirtyPredicate.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/DeltaAwareDirtyPredicate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/EqualsDirtyPredicate.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/EqualsDirtyPredicate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/GemFireOperationsSessionRepositorySupport.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/GemFireOperationsSessionRepositorySupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/GemFireUtils.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/GemFireUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/IdentityEqualsDirtyPredicate.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/IdentityEqualsDirtyPredicate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/IsDirtyPredicate.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/IsDirtyPredicate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/SessionIdHolder.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/SessionIdHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/SessionUtils.java
+++ b/spring-session-data-geode/src/main/java/org/springframework/session/data/gemfire/support/SessionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/AbstractGemFireOperationsSessionRepositoryTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/AbstractGemFireOperationsSessionRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/GemFireOperationsSessionRepositoryTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/GemFireOperationsSessionRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionConfigurationTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionAttributesIndexFactoryBeanTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionAttributesIndexFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionCacheTypeAwareRegionFactoryBeanTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SessionCacheTypeAwareRegionFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SpringSessionGemFireConfigurerUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/config/annotation/web/http/support/SpringSessionGemFireConfigurerUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/SessionExpirationPolicyUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/SessionExpirationPolicyUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/config/FixedDurationExpirationSessionRepositoryBeanPostProcessorUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/config/FixedDurationExpirationSessionRepositoryBeanPostProcessorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/config/SessionExpirationTimeoutAwareBeanPostProcessorUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/config/SessionExpirationTimeoutAwareBeanPostProcessorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/repository/FixedDurationExpirationSessionRepositoryUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/repository/FixedDurationExpirationSessionRepositoryUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/support/FixedTimeoutSessionExpirationPolicyUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/support/FixedTimeoutSessionExpirationPolicyUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/support/IdleTimeoutSessionExpirationPolicyUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/support/IdleTimeoutSessionExpirationPolicyUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/support/SessionExpirationPolicyCustomExpiryAdapterUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/expiration/support/SessionExpirationPolicyCustomExpiryAdapterUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/SessionSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/SessionSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/AbstractDataSerializableSessionSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/AbstractDataSerializableSessionSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionAttributesSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionAttributesSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/provider/DataSerializableSessionSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializerSessionSerializerAdapterUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/support/DataSerializerSessionSerializerAdapterUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/support/WirableDataSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/data/support/WirableDataSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/AbstractPdxSerializableSessionSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/AbstractPdxSerializableSessionSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/provider/PdxSerializableSessionSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/provider/PdxSerializableSessionSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/support/ComposablePdxSerializerTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/support/ComposablePdxSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/support/PdxSerializerSessionSerializerAdapterTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/serialization/pdx/support/PdxSerializerSessionSerializerAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/DeltaAwareDirtyPredicateUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/DeltaAwareDirtyPredicateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/EqualsDirtyPredicateUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/EqualsDirtyPredicateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/GemFireUtilsTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/GemFireUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/IdentityEqualsDirtyPredicateUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/IdentityEqualsDirtyPredicateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/IsDirtyPredicateUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/IsDirtyPredicateUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/SessionIdHolderTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/SessionIdHolderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/SessionUtilsUnitTests.java
+++ b/spring-session-data-geode/src/test/java/org/springframework/session/data/gemfire/support/SessionUtilsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-geode/src/test/resources/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests-context.xml
+++ b/spring-session-data-geode/src/test/resources/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://geode.apache.org/schema/cache/cache-1.0.xsd with 1 occurrences migrated to:  
  https://geode.apache.org/schema/cache/cache-1.0.xsd ([https](https://geode.apache.org/schema/cache/cache-1.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/gemfire/spring-gemfire.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/gemfire/spring-gemfire.xsd ([https](https://www.springframework.org/schema/gemfire/spring-gemfire.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* [ ] http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://geode.apache.org/schema/cache with 2 occurrences
* http://java.sun.com/xml/ns/javaee with 4 occurrences
* http://www.springframework.org/schema/beans with 8 occurrences
* http://www.springframework.org/schema/context with 6 occurrences
* http://www.springframework.org/schema/gemfire with 8 occurrences
* http://www.springframework.org/schema/p with 4 occurrences
* http://www.springframework.org/schema/util with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 7 occurrences