### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -10,8 +10,8 @@ By participating, you  are expected to uphold this code. Please report unaccepta
 == Using GitHub issues
 
 We use GitHub issues to track bugs and enhancements. If you have a general usage question
-please ask on http://stackoverflow.com[Stack Overflow]. The Spring Session team and the
-broader community monitor the http://stackoverflow.com/tags/spring-session[`spring-session`]
+please ask on https://stackoverflow.com[Stack Overflow]. The Spring Session team and the
+broader community monitor the https://stackoverflow.com/tags/spring-session[`spring-session`]
 tag.
 
 If you are reporting a bug, please help to speed up problem diagnosis by providing as much

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://travis-ci.org/spring-projects/spring-session.svg?branch=master["Bu
 _Spring Session_ aims to provide a common infrastructure for managing Sessions.
 
 _Spring Session for Apache Geode_ positions either https://pivotal.io/pivotal-gemfire[Pivotal GemFire]
-or http://geode.apache.org/[Apache Geode] as a Session Repository provider.
+or https://geode.apache.org/[Apache Geode] as a Session Repository provider.
 
 This provides many benefits including:
 
@@ -31,7 +31,7 @@ and Javadoc is available https://docs.spring.io/autorepo/docs/spring-session-dat
 = Spring Session Project Site
 
 You can find the documentation, issue management, support, samples, and guides for using _Spring Session_
-at http://projects.spring.io/spring-session/
+at https://projects.spring.io/spring-session/
 
 = License
 

--- a/docs/src/docs/asciidoc/guides/boot-gemfire-with-scoped-proxies.adoc
+++ b/docs/src/docs/asciidoc/guides/boot-gemfire-with-scoped-proxies.adoc
@@ -166,19 +166,19 @@ of servers (a.k.a. data nodes), it is more common for clients to connect to 1 or
 in the same cluster. A Locator passes meta-data to clients about the servers available in the cluster, the individual
 server load and which servers have the client's data of interest, which is particularly important for direct,
 single-hop data access and latency-sensitive operations.  See more details about the
-http://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
+https://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
 in the Apache Geode User Guide.
 
 NOTE: For more information on configuring _Spring Data Geode_, refer to the
-http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
+https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
 
 ==== Enabling Pivotal GemFire HttpSession Management
 
 `@EnableGemFireHttpSession` enables a developer to configure certain aspects of both _Spring Session_ and Apache Geode
 out-of-the-box using the following attributes:
 
-* `clientRegionShortcut` - specifies the Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-used on the client with http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
+* `clientRegionShortcut` - specifies the Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+used on the client with https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
 (default is `PROXY`).  This attribute is only used when configuring the client `Region`.
 * `indexableSessionAttributes` - Identifies session attributes by name that should be indexed for querying purposes.
 Only session attributes explicitly identified by name will be indexed. This is useful in situations where your application
@@ -188,8 +188,8 @@ is looking up the `HttpSession` by the currently authenticated principal's name,
 "_gemfirePool_").
 * `regionName` - specifies the name of the Apache Geode Region used to store and manage `HttpSession` state
 (defaults to "_ClusteredSpringSessions_").
-* `serverRegionShortcut` - specifies the Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-used on the server with http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
+* `serverRegionShortcut` - specifies the Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+used on the server with https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).  This attribute is only used when configuring server Regions, or when Apache Geode's P2P
 topology is employed.
 * `sessionSerializerBeanName` - refers to the name of the bean that handles serialization of the `HttpSession` state

--- a/docs/src/docs/asciidoc/guides/boot-gemfire.adoc
+++ b/docs/src/docs/asciidoc/guides/boot-gemfire.adoc
@@ -141,17 +141,17 @@ of Apache Geode servers (data nodes), it is more common for clients to connect t
 in the cluster.  A Locator passes meta-data to clients about the servers available in the cluster, the server load
 and which servers have the client's data of interest, which is particularly important for direct, single-hop data access
 and latency-sensitive operations.  See more details about the
-http://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
+https://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
 in the Apache Geode User Guide.
 
 NOTE: For more information on configuring _Spring Data Geode, refer to the
-http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
+https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
 
 `@EnableGemFireHttpSession` enables a developer to configure certain aspects of both _Spring Session_ and Apache Geode
 out-of-the-box using the following attributes:
 
-* `clientRegionShortcut` - specifies Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-on the client with a Apache Geode http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
+* `clientRegionShortcut` - specifies Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+on the client with a Apache Geode https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
 (default is `PROXY`).  This attribute is only used when configuring client `Region`.
 * `indexableSessionAttributes` - Identifies the Session attributes by name that should be indexed for querying operations.
 Only Session attributes identified by name will be indexed.
@@ -160,8 +160,8 @@ Only Session attributes identified by name will be indexed.
 is only used when the application is a cache client.  Defaults to `gemfirePool`.
 * `regionName` - specifies the name of the Apache Geode `Region` used to store and manage `HttpSession` state
 (default is "*ClusteredSpringSessions*").
-* `serverRegionShortcut` - specifies Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-on the server using a Apache Geode http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
+* `serverRegionShortcut` - specifies Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+on the server using a Apache Geode https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).  This attribute is only used when configuring server `Regions`, or when a P2P topology is employed.
 
 NOTE: It is important to remember that the Apache Geode client `Region` name must match a server `Region`
@@ -230,7 +230,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local Apache Geode installation.  For more information on installation,
-see http://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
+see https://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
 
 If you like, you can easily remove the Session using `gfsh`.
 
@@ -261,7 +261,7 @@ gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7f
 ....
 
 NOTE: The _Apache Geode User Guide_ contains more detailed instructions on using
-http://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
+https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at `http://localhost:8080/` again and observe the attribute we added is no longer displayed.
 

--- a/docs/src/docs/asciidoc/guides/java-gemfire-clientserver.adoc
+++ b/docs/src/docs/asciidoc/guides/java-gemfire-clientserver.adoc
@@ -103,17 +103,17 @@ of Apache Geode servers (data nodes), it is more common for clients to connect t
 in the cluster.  A Locator passes meta-data to clients about the servers available in the cluster, the server load
 and which servers have the client's data of interest, which is particularly important for direct, single-hop data access
 and latency-sensitive operations.  See more details about the
-http://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
+https://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
 in the Apache Geode User Guide.
 
 NOTE: For more information on configuring _Spring Data Geode, refer to the
-http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
+https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
 
 `@EnableGemFireHttpSession` enables a developer to configure certain aspects of both _Spring Session_ and Apache Geode
 out-of-the-box using the following attributes:
 
-* `clientRegionShortcut` - specifies Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-on the client with a Apache Geode http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
+* `clientRegionShortcut` - specifies Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+on the client with a Apache Geode https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
 (default is `PROXY`).  This attribute is only used when configuring a client `Region`.
 * `indexableSessionAttributes` - Identifies the Session attributes by name that should be indexed for querying operations.
 Only Session attributes identified by name will be indexed.
@@ -122,8 +122,8 @@ Only Session attributes identified by name will be indexed.
 is only used when the application is a cache client.  Defaults to `gemfirePool`.
 * `regionName` - specifies the name of the Apache Geode `Region` used to store and manage `HttpSession` state
 (default is "*ClusteredSpringSessions*").
-* `serverRegionShortcut` - specifies Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-on the server using a Apache Geode http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
+* `serverRegionShortcut` - specifies Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+on the server using a Apache Geode https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).  This attribute is only used when configuring server `Regions`, or when a P2P topology is employed.
 
 NOTE: It is important to remember that the Apache Geode client `Region` name must match a server `Region`
@@ -237,7 +237,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local Apache Geode installation.  For more information on installation,
-see http://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
+see https://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
 
 If you like, you can easily remove the Session using `gfsh`.
 
@@ -268,7 +268,7 @@ gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7f
 ....
 
 NOTE: The _Apache Geode User Guide_ contains more detailed instructions on using
-http://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
+https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at `http://localhost:8080/` again and observe the attribute we added is no longer displayed.
 

--- a/docs/src/docs/asciidoc/guides/java-gemfire-p2p.adoc
+++ b/docs/src/docs/asciidoc/guides/java-gemfire-p2p.adoc
@@ -93,13 +93,13 @@ the creation of a peer cache instance.
 service to allow JMX clients (e.g. Apache Geode's _Gfsh_ shell tool) to connect and inspect the server.
 
 NOTE: For more information on configuring _Spring Data Geode, refer to the
-http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
+https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
 
 `@EnableGemFireHttpSession` enables a developer to configure certain aspects of both _Spring Session_ and Apache Geode
 out-of-the-box using the following attributes:
 
-* `clientRegionShortcut` - specifies Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-on the client with a Apache Geode http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
+* `clientRegionShortcut` - specifies Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+on the client with a Apache Geode https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
 (default is `PROXY`).  This attribute is only used when configuring a client `Region`.
 * `indexableSessionAttributes` - Identifies the Session attributes by name that should be indexed for querying operations.
 Only Session attributes identified by name will be indexed.
@@ -108,8 +108,8 @@ Only Session attributes identified by name will be indexed.
 is only used when the application is a cache client.  Defaults to `gemfirePool`.
 * `regionName` - specifies the name of the Apache Geode `Region` used to store and manage `HttpSession` state
 (default is "*ClusteredSpringSessions*").
-* `serverRegionShortcut` - specifies Apache Geode http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
-on the server using a Apache Geode http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
+* `serverRegionShortcut` - specifies Apache Geode https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html[data management policy]
+on the server using a Apache Geode https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).  This attribute is only used when configuring server `Regions`, or when a P2P topology is employed.
 
 == Java Servlet Container Initialization
@@ -180,7 +180,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local Apache Geode installation.  For more information on installation,
-see http://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
+see https://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
 
 If you like, you can easily remove the Session using `gfsh`.
 
@@ -211,6 +211,6 @@ gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7f
 ....
 
 NOTE: The _Apache Geode User Guide_ contains more detailed instructions on using
-http://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
+https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at `http://localhost:8080/` again and observe the attribute we added is no longer displayed.

--- a/docs/src/docs/asciidoc/guides/xml-gemfire-clientserver.adoc
+++ b/docs/src/docs/asciidoc/guides/xml-gemfire-clientserver.adoc
@@ -87,7 +87,7 @@ include::{samples-dir}xml/gemfire-clientserver/src/main/webapp/WEB-INF/spring/se
 ----
 
 <1> (Optional) First, we can include a `Properties` bean to configure certain aspects of the Apache Geode `ClientCache`
-using http://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html[Pivotal GemFire Properties].
+using https://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html[Pivotal GemFire Properties].
 In this case, we are just setting Apache Geode's "`log-level`" from a application-specific System property,
 defaulting to "`warning`" if unspecified.
 <2> We must create an instance of an Apache Geode `ClientCache` initialized with our `gemfireProperties`.
@@ -101,11 +101,11 @@ of Apache Geode servers (data nodes), it is more common for clients to connect t
 in the cluster.  A Locator passes meta-data to clients about the servers available in the cluster, the server load
 and which servers have the client's data of interest, which is particularly important for direct, single-hop data access
 and latency-sensitive operations.  See more details about the
-http://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
+https://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html[Client/Server Deployment]
 in the Apache Geode User Guide.
 
 NOTE: For more information on configuring _Spring Data Geode, refer to the
-http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
+https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
 
 === Server Configuration
 
@@ -120,7 +120,7 @@ include::{samples-dir}xml/gemfire-clientserver/src/main/resources/META-INF/sprin
 ----
 
 <1> (Optional) First, we can include a `Properties` bean to configure certain aspects of the Apache Geode peer `Cache`
-using http://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html[Pivotal GemFire Properties].
+using https://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html[Pivotal GemFire Properties].
 In this case, we are just setting Apache Geode's "`log-level`" from a application-specific System property,
 defaulting to "`warning`" if unspecified.
 <2> We must configure an Apache Geode peer `Cache` instance initialized with the Apache Geode properties.
@@ -160,7 +160,7 @@ include::{samples-dir}xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml[t
 include::{samples-dir}xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml[tags=listeners]
 ----
 
-The http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
+The https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
 reads the `contextConfigLocation` context parameter value and picks up our _session-client.xml_ configuration file.
 
 Finally, we need to ensure that our Servlet container (i.e. Tomcat) uses our `springSessionRepositoryFilter`
@@ -174,7 +174,7 @@ The following snippet performs this last step for us:
 include::{samples-dir}xml/gemfire-clientserver/src/main/webapp/WEB-INF/web.xml[tags=springSessionRepositoryFilter]
 ----
 
-The http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
+The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
 will look up a bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`. For every HTTP request,
 the `DelegatingFilterProxy` is invoked, which delegates to the `springSessionRepositoryFilter`.
 // end::config[]
@@ -230,7 +230,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local Apache Geode installation.  For more information on installation,
-see http://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
+see https://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
 
 If you like, you can easily remove the session using `gfsh`.
 
@@ -261,7 +261,7 @@ gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7f
 ....
 
 NOTE: The _Apache Geode User Guide_ contains more detailed instructions on using
-http://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
+https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at `http://localhost:8080/` again and observe the attribute we added is no longer displayed.
 

--- a/docs/src/docs/asciidoc/guides/xml-gemfire-p2p.adoc
+++ b/docs/src/docs/asciidoc/guides/xml-gemfire-p2p.adoc
@@ -88,7 +88,7 @@ include::{samples-dir}xml/gemfire-p2p/src/main/webapp/WEB-INF/spring/session.xml
 ----
 
 <1> (Optional) First, we can include a `Properties` bean to configure certain aspects of the Apache Geode peer `Cache`
-using http://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html[Pivotal GemFire Properties].
+using https://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html[Pivotal GemFire Properties].
 In this case, we are just setting Apache Geode's "`log-level`" from a application-specific System property,
 defaulting to "`warning`" if unspecified.
 <2> We must configure an Apache Geode peer `Cache` instance initialized with the Apache Geode properties.
@@ -98,7 +98,7 @@ TIP: Additionally, we have configured this data node (server) as a Apache Geode 
 JMX properties that enable JMX client (e.g. _Gfsh_) to connect to this running server.
 
 NOTE: For more information on configuring _Spring Data Geode, refer to the
-http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
+https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[Reference Guide].
 
 == XML Servlet Container Initialization
 
@@ -117,7 +117,7 @@ include::{samples-dir}xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml[tags=conte
 include::{samples-dir}xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml[tags=listeners]
 ----
 
-The http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
+The https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
 reads the `contextConfigLocation` context parameter value and picks up our _session.xml_ configuration file.
 
 Finally, we need to ensure that our Servlet container (i.e. Tomcat) uses our `springSessionRepositoryFilter`
@@ -131,7 +131,7 @@ The following snippet performs this last step for us:
 include::{samples-dir}xml/gemfire-p2p/src/main/webapp/WEB-INF/web.xml[tags=springSessionRepositoryFilter]
 ----
 
-The http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
+The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
 will look up a bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`. For every HTTP request
 the `DelegatingFilterProxy` is invoked, delegating to the `springSessionRepositoryFilter`.
 // end::config[]
@@ -175,7 +175,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local Apache Geode installation.  For more information on installation,
-see http://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
+see https://geode.apache.org/docs/guide/12/prereq_and_install.html[Prerequisites and Installation Instructions].
 
 If you like, you can easily remove the session using `gfsh`.
 
@@ -206,6 +206,6 @@ gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7f
 ....
 
 NOTE: The _Apache Geode User Guide_ contains more detailed instructions on using
-http://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
+https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at `http://localhost:8080/` again and observe the attribute we added is no longer displayed.

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -2,9 +2,9 @@
 John Blum
 :data-store-version: 16
 :data-store-name: Apache Geode
-:data-store-docs: http://geode.apache.org/docs/guide/{data-store-version}
-:data-store-javadoc: http://geode.apache.org/releases/latest/javadoc
-:data-store-website: http://geode.apache.org
+:data-store-docs: https://geode.apache.org/docs/guide/{data-store-version}
+:data-store-javadoc: https://geode.apache.org/releases/latest/javadoc
+:data-store-website: https://geode.apache.org
 :sdg-name: Spring Data for {data-store-name}
 :sdg-docs: https://docs.spring.io/spring-data/geode/docs/current/reference/html
 :sdg-javadoc: https://docs.spring.io/spring-data/geode/docs/current/api
@@ -1135,7 +1135,7 @@ Please find additional information below.
 [[community-support]]
 === Support
 
-You can get help by asking questions on http://stackoverflow.com/questions/tagged/spring-session[StackOverflow with the tag `spring-session`].
+You can get help by asking questions on https://stackoverflow.com/questions/tagged/spring-session[StackOverflow with the tag `spring-session`].
 Similarly we encourage helping others by answering questions on _StackOverflow_.
 
 [[community-source]]

--- a/samples/boot/gemfire-with-scoped-proxies/src/main/resources/templates/index.html
+++ b/samples/boot/gemfire-with-scoped-proxies/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
 <head>
 	<title>Request and Session Counts</title>
 	<link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" href="/webjars/bootstrap/css/bootstrap.min.css"/>

--- a/samples/boot/gemfire/src/main/resources/templates/index.html
+++ b/samples/boot/gemfire/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
 <head>
 	<title>Session Attributes</title>
 	<link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" href="/webjars/bootstrap/css/bootstrap.min.css"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ with 6 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html ([https](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html) result 200).
* [ ] http://geode.apache.org with 1 occurrences migrated to:  
  https://geode.apache.org ([https](https://geode.apache.org) result 200).
* [ ] http://geode.apache.org/ with 1 occurrences migrated to:  
  https://geode.apache.org/ ([https](https://geode.apache.org/) result 200).
* [ ] http://geode.apache.org/docs/guide/ with 1 occurrences migrated to:  
  https://geode.apache.org/docs/guide/ ([https](https://geode.apache.org/docs/guide/) result 200).
* [ ] http://geode.apache.org/docs/guide/12/developing/region_options/region_types.html with 8 occurrences migrated to:  
  https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html ([https](https://geode.apache.org/docs/guide/12/developing/region_options/region_types.html) result 200).
* [ ] http://geode.apache.org/docs/guide/12/prereq_and_install.html with 5 occurrences migrated to:  
  https://geode.apache.org/docs/guide/12/prereq_and_install.html ([https](https://geode.apache.org/docs/guide/12/prereq_and_install.html) result 200).
* [ ] http://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html with 3 occurrences migrated to:  
  https://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html ([https](https://geode.apache.org/docs/guide/12/reference/topics/gemfire_properties.html) result 200).
* [ ] http://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html with 5 occurrences migrated to:  
  https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html ([https](https://geode.apache.org/docs/guide/12/tools_modules/gfsh/chapter_overview.html) result 200).
* [ ] http://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html with 4 occurrences migrated to:  
  https://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html ([https](https://geode.apache.org/docs/guide/12/topologies_and_comm/cs_configuration/standard_client_server_deployment.html) result 200).
* [ ] http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html with 4 occurrences migrated to:  
  https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html ([https](https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/RegionShortcut.html) result 200).
* [ ] http://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html with 4 occurrences migrated to:  
  https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html ([https](https://geode.apache.org/releases/latest/javadoc/org/apache/geode/cache/client/ClientRegionShortcut.html) result 200).
* [ ] http://projects.spring.io/spring-session/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-session/ ([https](https://projects.spring.io/spring-session/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-session with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-session ([https](https://stackoverflow.com/questions/tagged/spring-session) result 200).
* [ ] http://stackoverflow.com/tags/spring-session with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-session ([https](https://stackoverflow.com/tags/spring-session) result 200).
* [ ] http://www.thymeleaf.org with 2 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd with 2 occurrences migrated to:  
  https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd ([https](https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://geode.apache.org/releases/latest/javadoc with 1 occurrences migrated to:  
  https://geode.apache.org/releases/latest/javadoc ([https](https://geode.apache.org/releases/latest/javadoc) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 4 occurrences
* http://localhost with 4 occurrences
* http://localhost:%s with 1 occurrences
* http://localhost:8080/ with 10 occurrences
* http://localhost:8080/counts with 2 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences
* http://www.webjars.org/tags with 4 occurrences