### PR TITLE
Add index page link; Add stylesheet location to gfsh docs

### DIFF
--- a/docs/spring-session-docs.gradle
+++ b/docs/spring-session-docs.gradle
@@ -17,8 +17,6 @@ dependencies {
 }
 
 def versions = dependencyManagement.managedVersions
-def relativePathToSpringCss = "css/spring.css"
-def pathToSpringCss = new File(project.getBuildDir(), relativePathToSpringCss).getAbsolutePath()
 
 asciidoctor {
 
@@ -30,7 +28,6 @@ asciidoctor {
 		'download-url' : "https://github.com/spring-projects/spring-session-data-geode/archive/${ghTag}.zip",
 		'docinfodir@': ".",
 		'highlightjsdir@': "js/highlight",
-		'stylesheet' : pathToSpringCss,
 //		'spring-version' : "$springVersion",
 		'spring-version' : versions['org.springframework:spring-core'],
 		'spring-data-commons-version' : "$springDataCommonsVersion",

--- a/docs/src/docs/asciidoc/guides/boot-gemfire-with-gfsh-servers.adoc
+++ b/docs/src/docs/asciidoc/guides/boot-gemfire-with-gfsh-servers.adoc
@@ -28,6 +28,9 @@ to serialize the `HttpSession`.  Therefore, it is necessary to perform additiona
 {data-store-name}'s _DataSerialization_ capabilities on the servers so {data-store-name} properly recognizes
 the Spring Session types.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.

--- a/docs/src/docs/asciidoc/guides/boot-gemfire-with-scoped-proxies.adoc
+++ b/docs/src/docs/asciidoc/guides/boot-gemfire-with-scoped-proxies.adoc
@@ -33,6 +33,9 @@ a Spring Web MVC application making use of an `HttpSession`.
 NOTE: The completed guide can be found below, in section
 <<spring-session-sample-boot-geode-with-scoped-proxies,Sample Spring Boot Web Application using Apache Geode-managed HttpSessions with Request and Session Scoped Proxy Beans>>.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.

--- a/docs/src/docs/asciidoc/guides/boot-gemfire.adoc
+++ b/docs/src/docs/asciidoc/guides/boot-gemfire.adoc
@@ -15,6 +15,9 @@ making use of the `HttpSession`.
 NOTE: The completed guide can be found in the
 <<spring-session-sample-boot-geode,Spring Boot Sample Web Application with an Apache Geode managed HttpSession>>.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.

--- a/docs/src/docs/asciidoc/guides/docinfo-footer.html
+++ b/docs/src/docs/asciidoc/guides/docinfo-footer.html
@@ -1,0 +1,2 @@
+<script type="text/javascript" src="../js/tocbot/tocbot.min.js"></script>
+<script type="text/javascript" src="../js/toc.js"></script>

--- a/docs/src/docs/asciidoc/guides/gfsh.adoc
+++ b/docs/src/docs/asciidoc/guides/gfsh.adoc
@@ -1,3 +1,5 @@
+:stylesdir: ../
+
 NOTE: The following instructions assume you have installed a local Apache Geode installation.  For more information
 on installation, see {data-store-docs}/prereq_and_install.html[Prerequisites and Installation Instructions].
 

--- a/docs/src/docs/asciidoc/guides/java-gemfire-clientserver.adoc
+++ b/docs/src/docs/asciidoc/guides/java-gemfire-clientserver.adoc
@@ -11,6 +11,9 @@ a Web application's `javax.servlet.http.HttpSession` using Java Configuration.
 NOTE: The completed guide can be found in the
 <<spring-session-sample-java-geode-clientserver,HttpSession managed by a Java configured, Apache Geode Client/Server Sample Application>>.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.

--- a/docs/src/docs/asciidoc/guides/java-gemfire-p2p.adoc
+++ b/docs/src/docs/asciidoc/guides/java-gemfire-p2p.adoc
@@ -10,6 +10,9 @@ a Web application's `javax.servlet.http.HttpSession` using Java configuration.
 
 NOTE: The completed guide can be found in the <<spring-session-sample-java-gemfire-p2p,HttpSession with Apache Geode (P2P) Sample Application>>.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.

--- a/docs/src/docs/asciidoc/guides/xml-gemfire-clientserver.adoc
+++ b/docs/src/docs/asciidoc/guides/xml-gemfire-clientserver.adoc
@@ -10,6 +10,9 @@ a Web application's `javax.servlet.http.HttpSession` using XML Configuration.
 
 NOTE: The completed guide can be found in the <<spring-session-sample-xml-geode-clientserver,Spring XML Configuation>>.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.

--- a/docs/src/docs/asciidoc/guides/xml-gemfire-p2p.adoc
+++ b/docs/src/docs/asciidoc/guides/xml-gemfire-p2p.adoc
@@ -11,6 +11,9 @@ a Web application's `javax.servlet.http.HttpSession` using XML configuration.
 NOTE: The completed guide can be found in the
 <<spring-session-sample-xml-gemfire-p2p,HttpSession with Apache Geode (P2P) using XML Sample Application>>.
 
+[#index-link]
+link:../index.html[Index]
+
 == Updating Dependencies
 
 Before using Spring Session, you must ensure that the required dependencies are included.


### PR DESCRIPTION
The file `gfsh.adoc` was missing the stylesheet location, causing the error `No such file or directory ...`.
This PR also adds the `index-link` to each of the guides, in order to make the "Back to Index" button return to the correct location. 