### PR TITLE
Connect build to ge.spring.io to benefit from deep build insights and faster builds

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,8 @@ image:https://badges.gitter.im/spring-projects/spring-session.svg[link="https://
 
 image:https://travis-ci.org/spring-projects/spring-session.svg?branch=master["Build Status", link="https://travis-ci.org/spring-projects/spring-session-data-geode"]
 
+image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?&search.rootProjectNames=ROOT_PROJECT_NAME"]
+
 [[ssdg]]
 == Spring Session for Apache Geode
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ image:https://badges.gitter.im/spring-projects/spring-session.svg[link="https://
 
 image:https://travis-ci.org/spring-projects/spring-session.svg?branch=master["Build Status", link="https://travis-ci.org/spring-projects/spring-session-data-geode"]
 
-image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?&search.rootProjectNames=ROOT_PROJECT_NAME"]
+image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?&search.rootProjectNames=spring-session-data-geode-build"]
 
 [[ssdg]]
 == Spring Session for Apache Geode

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.caching=true
 systemProp.user.name=jblum
 antlrVersion=2.7.7
 apacheGeodeVersion=1.15.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,11 @@ pluginManagement {
 	}
 }
 
+plugins {
+    id 'com.gradle.enterprise' version '3.14.1'
+    id 'io.spring.ge.conventions' version '0.0.14'
+}
+
 rootProject.name = 'spring-session-data-geode-build'
 
 FileTree buildFiles = fileTree(rootDir) {


### PR DESCRIPTION
Note: We have been informed that this project will soon be end-of-life, so we understand if this pull request is not integrated.

This pull request connects the build to the Gradle Enterprise instance at https://ge.spring.io/. This allows the spring-session-data-geode project to benefit from deep build insights provided by build scans and faster build speeds for all contributors as a result of remote build caching. 

This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by spring-session-data-geode and all other Spring projects. On this Gradle Enterprise instance, spring-session-data-geode will have access not only to all of the published build scans, but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

[Spring Boot](https://ge.spring.io/scans?search.rootProjectNames=spring-boot-build), [Spring Framework](https://ge.spring.io/scans?search.rootProjectNames=spring), and [Spring Security](https://ge.spring.io/scans?search.rootProjectNames=spring-security) are already connected to https://ge.spring.io/ and are benefiting from these features. 

For these features to be made possible, appropriate access must be configured to publish build scans and to write to the remote build cache. To ensure a consistent experience for all Spring contributors, the [Spring Gradle Enterprise Conventions](https://github.com/spring-io/gradle-enterprise-conventions) plugin is used. Its documentation details how to configure credentials [to publish build scans](https://github.com/spring-io/gradle-enterprise-conventions#build-scan-publishing-credentials) and [for writing to the remote build cache](https://github.com/spring-io/gradle-enterprise-conventions#credentials).

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.